### PR TITLE
Allow use of a config file to exclude paths from build

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -13,6 +13,8 @@ var wrench   = require('wrench');
 var inquirer = require('inquirer');
 var mime = require('mime');
 
+var CONFIG_FILE_PATH = 'webhookconfig.json'
+
 
 module.exports = function (options) {
 
@@ -133,7 +135,22 @@ module.exports = function (options) {
       {
         excludedPaths = excludedPaths.concat('package.json', 'node_modules', 'Gruntfile.js', 'libs', 'tasks', 'options');
       }
-      
+
+      if (fs.existsSync(CONFIG_FILE_PATH)) {
+        var raw = fs.readFileSync(CONFIG_FILE_PATH, 'utf8');
+        if (raw.length !== 0) {
+          var contents;
+          try {
+            contents = JSON.parse(raw);
+          } catch(err) {
+            console.log('Unable to parse '.red + CONFIG_FILE_PATH.red + ' as JSON'.red);
+          }
+          if (contents && contents.pathsToExclude) {
+            excludedPaths = excludedPaths.concat(contents.pathsToExclude);
+          }
+        }
+      }
+
       files.forEach(function(file) {
         for(var i in excludedPaths)
         {


### PR DESCRIPTION
Add an optional config file at webhookconfig.json with
single option for filepaths to exclude from build
(pathsToExclude). This allows other useful files to be
placed in the project without inhibiting deployment.

For example, including a python script and a virtual
environment currently breaks deployment - now you can
add the virtual environment to filesToExclude via the
config.